### PR TITLE
Revert PR #8 footer geolocation changes (restore api.country.is)

### DIFF
--- a/themes/soldaini/layouts/partials/footer.html
+++ b/themes/soldaini/layouts/partials/footer.html
@@ -221,19 +221,27 @@
         "VG", // the British Virgin Islands
     ]);
 
+    const countryName = (code) => {
+        try {
+            return new Intl.DisplayNames(["en"], { type: "region" }).of(code);
+        } catch {
+            return null;
+        }
+    };
+
     const flag = (code) =>
         String.fromCodePoint(...[...code.toUpperCase()].map((c) => 0x1f1e6 + c.charCodeAt(0) - 65));
 
     const el = document.getElementById("greeting");
-    if (!el) return;
     el.textContent = fallbacks[Math.floor(Math.random() * fallbacks.length)];
 
-    fetch("https://freeipapi.com/api/json")
+    fetch("https://api.country.is")
         .then((r) => r.json())
-        .then(({ countryName, countryCode }) => {
-            if (!countryName || !countryCode) return;
-            const the = theCountries.has(countryCode) ? "the " : "";
-            el.textContent = `${the}${countryName}! ${flag(countryCode)}`;
+        .then(({ country }) => {
+            const name = countryName(country);
+            if (!name) return;
+            const the = theCountries.has(country) ? "the " : "";
+            el.textContent = `${the}${name}! ${flag(country)}`;
         })
         .catch(() => {});
 </script>


### PR DESCRIPTION
### Motivation
- Undo the recent footer geolocation changes that switched the visitor greeting to the `freeipapi.com`/`ipwho.is` response shape because the newer integration changed the response shape and caused brittle behavior. 
- Restore the prior country-name resolution and flag rendering so the footer greeting uses the same reliable lookup and formatting as before.

### Description
- Restored previous logic in `themes/soldaini/layouts/partials/footer.html` to use `https://api.country.is` for lookups and the `{ country }` response shape. 
- Re-added the `Intl.DisplayNames`-based `countryName` helper and the original `theCountries` + flag rendering behavior for human-readable country names and emoji flags. 
- Removed the `freeipapi.com` response-shape handling and the `countryName/countryCode` branch introduced in the recent change, reverting to the pre-PR#8 greeting flow.

### Testing
- Ran `uv run hugo-cli` and the site built successfully. 
- Attempted `uv run preview-png -- /` but it failed because Playwright/browser host dependencies and remote browser downloads are not available in this environment, so a screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f0e898ba4832db8faf9333ffbe2f5)