### PR TITLE
Improve PageSpeed performance and accessibility

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -4,7 +4,12 @@ title = "Luca Soldaini"
 
 <div id="avatar-container">
     <div id="front-avatar">
-        <img src="personal-me/me-512.webp" alt="Half bust portrait picture of Luca Soldaini." class="avatar">
+        <img src="personal-me/me-512.webp"
+             srcset="personal-me/me-512.webp 512w, personal-me/me-1024.webp 1024w"
+             sizes="256px"
+             width="512" height="512"
+             fetchpriority="high"
+             alt="Half bust portrait picture of Luca Soldaini." class="avatar">
     </div>
     <div id="back-avatar">
         <img src="/alt.webp" loading="lazy" alt="A raccoon wearing a top hat and holding a pizza slice." class="avatar">

--- a/themes/soldaini/assets/sass/theme.scss
+++ b/themes/soldaini/assets/sass/theme.scss
@@ -10,6 +10,15 @@
     font-style: normal italic;
 }
 
+@font-face {
+    font-family: "Atkinson Fallback";
+    src: local("Arial"), local("Helvetica Neue"), local("Helvetica");
+    size-adjust: 100.5%;
+    ascent-override: 96%;
+    descent-override: 24%;
+    line-gap-override: 0%;
+}
+
 @property --avatar-glow {
     syntax: "<number>";
     inherits: true;
@@ -35,6 +44,7 @@
     --code: #{$code};
     --code-background: #{$code-background};
     --shadow: #{$shadow};
+    --muted-accessible: #5f6976;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -61,11 +71,16 @@
         --code: #{$code-dark};
         --code-background: #{$code-background-dark};
         --shadow: #{$shadow-dark};
+        --muted-accessible: #{$muted-dark};
     }
 }
 
 * {
     box-sizing: border-box;
+}
+
+[hidden] {
+    display: none !important;
 }
 
 html {
@@ -76,7 +91,7 @@ html {
 
 body {
     margin: 0;
-    font-family: "Atkinson Hyperlegible", sans-serif;
+    font-family: "Atkinson Hyperlegible", "Atkinson Fallback", sans-serif;
     font-size: $base-font-size;
     line-height: $base-line-height;
     color: var(--ink);
@@ -101,6 +116,21 @@ hr {
     max-width: $max-width;
     margin: 0 auto;
     padding: 0 $gutter;
+}
+
+// Flex & spacing utilities (replaces Bootstrap CDN)
+.flex-column { flex-direction: column; }
+.flex-row { flex-direction: row; }
+.flex-wrap { flex-wrap: wrap; }
+.justify-content-end { justify-content: flex-end; }
+.text-nowrap { white-space: nowrap; }
+.text-center { text-align: center; }
+.p-0 { padding: 0; }
+.mx-0 { margin-left: 0; margin-right: 0; }
+.mb-2 { margin-bottom: 0.5rem; }
+@media (min-width: 576px) {
+    .flex-sm-row { flex-direction: row; }
+    .ms-sm-auto { margin-left: auto !important; }
 }
 
 .site-header {
@@ -634,8 +664,19 @@ sup:focus-within .footnote-popup {
 }
 
 .navbar {
+    position: relative;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
     padding-bottom: 0.75rem;
     gap: 0.5rem;
+}
+
+@media (min-width: 576px) {
+    .navbar-expand-sm {
+        flex-wrap: nowrap;
+    }
 }
 
 .navbar-brand {
@@ -659,6 +700,7 @@ h1.navbar-h1 {
 }
 
 .navbar-nav {
+    display: flex;
     gap: 0.5rem;
     align-items: center;
 }
@@ -735,6 +777,7 @@ h1.navbar-h1 {
     filter: blur(28px);
     opacity: calc(var(--avatar-glow) * var(--blob-opacity, 1));
     transform: scale(calc(0.65 + var(--avatar-glow) * 0.25));
+    will-change: transform, opacity;
     transition:
         opacity 1.5s cubic-bezier(0.16, 1, 0.3, 1),
         transform 1.5s cubic-bezier(0.16, 1, 0.3, 1);
@@ -921,98 +964,38 @@ h1.navbar-h1 {
 }
 
 @keyframes avatar-swirl-1 {
-    0% {
-        transform: translate(0%, 0%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(0deg);
-        border-radius: 30% 70% 55% 45% / 65% 35% 70% 30%;
-    }
-    33% {
-        transform: translate(4%, -3%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(120deg);
-        border-radius: 55% 45% 35% 65% / 40% 60% 45% 55%;
-    }
-    66% {
-        transform: translate(-3%, 4%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(240deg);
-        border-radius: 70% 30% 60% 40% / 55% 45% 35% 65%;
-    }
-    100% {
-        transform: translate(0%, 0%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(360deg);
-        border-radius: 30% 70% 55% 45% / 65% 35% 70% 30%;
-    }
+    0%   { transform: translate(0%, 0%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(0deg); }
+    33%  { transform: translate(4%, -3%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(120deg); }
+    66%  { transform: translate(-3%, 4%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(240deg); }
+    100% { transform: translate(0%, 0%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(360deg); }
 }
 
 @keyframes avatar-swirl-2 {
-    0% {
-        transform: translate(0%, 0%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(0deg);
-        border-radius: 65% 35% 40% 60% / 35% 60% 40% 65%;
-    }
-    33% {
-        transform: translate(-4%, 2%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(-120deg);
-        border-radius: 40% 60% 55% 45% / 60% 35% 65% 40%;
-    }
-    66% {
-        transform: translate(3%, -3%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(-240deg);
-        border-radius: 50% 50% 35% 65% / 45% 55% 50% 50%;
-    }
-    100% {
-        transform: translate(0%, 0%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(-360deg);
-        border-radius: 65% 35% 40% 60% / 35% 60% 40% 65%;
-    }
+    0%   { transform: translate(0%, 0%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(0deg); }
+    33%  { transform: translate(-4%, 2%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(-120deg); }
+    66%  { transform: translate(3%, -3%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(-240deg); }
+    100% { transform: translate(0%, 0%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(-360deg); }
 }
 
 @keyframes avatar-swirl-3 {
-    0% {
-        transform: translate(0%, 0%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(0deg);
-        border-radius: 45% 55% 70% 30% / 55% 40% 60% 45%;
-    }
-    33% {
-        transform: translate(3%, 2%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(140deg);
-        border-radius: 60% 40% 45% 55% / 35% 65% 50% 50%;
-    }
-    66% {
-        transform: translate(-2%, -2%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(280deg);
-        border-radius: 35% 65% 55% 45% / 60% 40% 40% 60%;
-    }
-    100% {
-        transform: translate(0%, 0%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(360deg);
-        border-radius: 45% 55% 70% 30% / 55% 40% 60% 45%;
-    }
+    0%   { transform: translate(0%, 0%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(0deg); }
+    33%  { transform: translate(3%, 2%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(140deg); }
+    66%  { transform: translate(-2%, -2%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(280deg); }
+    100% { transform: translate(0%, 0%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(360deg); }
 }
 
 @keyframes avatar-swirl-4 {
-    0% {
-        transform: translate(0%, 0%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(0deg);
-        border-radius: 55% 45% 35% 65% / 40% 65% 35% 60%;
-    }
-    33% {
-        transform: translate(-3%, 3%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(-140deg);
-        border-radius: 35% 65% 50% 50% / 55% 45% 60% 40%;
-    }
-    66% {
-        transform: translate(2%, 1%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(-260deg);
-        border-radius: 60% 40% 65% 35% / 45% 55% 40% 60%;
-    }
-    100% {
-        transform: translate(0%, 0%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(-360deg);
-        border-radius: 55% 45% 35% 65% / 40% 65% 35% 60%;
-    }
+    0%   { transform: translate(0%, 0%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(0deg); }
+    33%  { transform: translate(-3%, 3%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(-140deg); }
+    66%  { transform: translate(2%, 1%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(-260deg); }
+    100% { transform: translate(0%, 0%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(-360deg); }
 }
 
 @keyframes avatar-swirl-5 {
-    0% {
-        transform: translate(0%, 0%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(0deg);
-        border-radius: 40% 60% 65% 35% / 60% 30% 70% 40%;
-    }
-    33% {
-        transform: translate(2%, -3%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(120deg);
-        border-radius: 65% 35% 40% 60% / 30% 70% 45% 55%;
-    }
-    66% {
-        transform: translate(-3%, 2%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(240deg);
-        border-radius: 50% 50% 55% 45% / 65% 35% 55% 45%;
-    }
-    100% {
-        transform: translate(0%, 0%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(360deg);
-        border-radius: 40% 60% 65% 35% / 60% 30% 70% 40%;
-    }
+    0%   { transform: translate(0%, 0%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(0deg); }
+    33%  { transform: translate(2%, -3%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(120deg); }
+    66%  { transform: translate(-3%, 2%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(240deg); }
+    100% { transform: translate(0%, 0%) scale(calc(0.7 + var(--avatar-glow) * 0.3)) rotate(360deg); }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -1303,7 +1286,7 @@ span.long-authors {
 #license {
     margin: 2rem auto 1rem;
     text-align: center;
-    color: var(--muted);
+    color: var(--muted-accessible);
     font-size: 0.7em;
 
     a {
@@ -1327,9 +1310,9 @@ span.long-authors {
         -webkit-mask-size: 100%;
         -webkit-mask-repeat: no-repeat;
         -webkit-mask-position: center;
-        vertical-align: middle;
+        vertical-align: -0.15em;
         margin-left: 2px;
-        background-color: var(--muted);
+        background-color: var(--muted-accessible);
     }
 }
 

--- a/themes/soldaini/layouts/partials/footer.html
+++ b/themes/soldaini/layouts/partials/footer.html
@@ -220,16 +220,19 @@
     buildFootnotePopovers();
 </script>
 
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-X15XFHYC4L"></script>
+<!-- Google tag (gtag.js) — deferred until after page load -->
 <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {
-        dataLayer.push(arguments);
-    }
-    gtag("js", new Date());
-
-    gtag("config", "G-X15XFHYC4L");
+    window.addEventListener('load', function() {
+        var s = document.createElement('script');
+        s.src = 'https://www.googletagmanager.com/gtag/js?id=G-X15XFHYC4L';
+        s.async = true;
+        document.head.appendChild(s);
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        window.gtag = gtag;
+        gtag('js', new Date());
+        gtag('config', 'G-X15XFHYC4L');
+    });
 </script>
 
 <!-- Greetings -->

--- a/themes/soldaini/layouts/partials/head.html
+++ b/themes/soldaini/layouts/partials/head.html
@@ -40,11 +40,14 @@
     <meta name="twitter:title" content="{{ $pageTitle }}">
     <meta name="twitter:description" content="{{ $description }}">
 
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet"
-        integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
+    <link rel="preload" as="font" type="font/woff2" href="/fonts/AtkinsonHyperlegibleNextVF-Variable.woff2" crossorigin>
 
     {{ $style := resources.Get "sass/theme.scss" | toCSS | minify | fingerprint }}
     <link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}">
+
+    {{ if .IsHome }}
+    <link rel="preload" as="image" type="image/webp" href="/personal-me/me-512.webp">
+    {{ end }}
 
     {{ with .Site.Params.favicon }}
     <link rel="shortcut icon" href="{{ . | relURL }}">
@@ -66,7 +69,6 @@
     <link rel="icon" type="image/png" sizes="192x192" href="/2nd-gen-favicon/composed/light/favicon-192.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/2nd-gen-favicon/composed/light/favicon-32.png">
     <link rel="icon" type="image/png" sizes="96x96" href="/2nd-gen-favicon/composed/light/favicon-96.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/2nd-gen-favicon/composed/light/favicon-32.png">
     <link rel="manifest" href="/2nd-gen-favicon/composed/light/manifest.json">
     <meta name="msapplication-TileColor" content="#f7f3ed">
     <meta name="msapplication-TileImage" content="/2nd-gen-favicon/composed/light/favicon-144-precomposed.png">


### PR DESCRIPTION
## Summary

Addresses findings from a PageSpeed Insights report (mobile score: 96) and a Pingdom HAR analysis. Key changes:

- **Remove Bootstrap CDN** — 29.3 KiB render-blocking cross-origin CSS of which 97% was unused. Replaced with ~15 lines of inline utility classes in `theme.scss`. Adds `[hidden] { display: none !important }` to preserve `hidden`-attribute behavior (used by publication topic filters).
- **LCP image optimization** — Add `fetchpriority="high"`, `srcset` (512w/1024w for retina), `width`/`height` attributes, and `<link rel="preload">` for the avatar image on the home page.
- **Reduce CLS** — Preload the Atkinson Hyperlegible font and add a `@font-face` fallback with metric overrides (`size-adjust`, `ascent-override`, `descent-override`) to minimize text reflow during font swap.
- **Fix non-composited animations** — Remove `border-radius` from `avatar-swirl-*` keyframes (non-compositable property behind a 28px blur). Add `will-change: transform, opacity` to `.avatar-blob`.
- **Accessibility** — Improve license text contrast to meet WCAG AA (new `--muted-accessible` variable). Fix license icon vertical alignment.
- **Defer Google Analytics** — Load gtag.js after `window.load` instead of eagerly, reducing main thread contention during initial render.
- **Remove duplicate favicon link** — The 16x16 icon link pointed to the 32px file, causing a duplicate request.

## Test plan

- [ ] Verify home page renders correctly (avatar, glow effect, layout, footer)
- [ ] Verify publications page topic filter buttons work (click to filter, click "All Topics" to reset)
- [ ] Verify navbar layout on mobile and desktop breakpoints
- [ ] Verify dark mode appearance
- [ ] Run PageSpeed Insights on the deployed site and confirm improved scores
- [ ] Check that Google Analytics still records page views

🤖 Generated with [Claude Code](https://claude.com/claude-code)