### PR TITLE
Disable author reveal animation on touch devices

### DIFF
--- a/themes/soldaini/layouts/partials/footer.html
+++ b/themes/soldaini/layouts/partials/footer.html
@@ -48,12 +48,14 @@
         var shortAuthors = span.getElementsByClassName("short-authors")[0];
         var longAuthors = span.getElementsByClassName("long-authors")[0];
         var prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        var isTouchDevice = window.matchMedia("(hover: none) and (pointer: coarse)").matches;
+        var allowAuthorAnimation = !prefersReduced && !isTouchDevice;
 
         function showLong(el) {
             el.style.display = "inline";
             el.classList.remove("author-reveal-out");
             el.classList.remove("author-reveal-static");
-            if (prefersReduced) {
+            if (!allowAuthorAnimation) {
                 el.classList.add("author-reveal-static");
                 return;
             }
@@ -69,7 +71,7 @@
         }
 
         function hideLong(el, onDone) {
-            if (prefersReduced) {
+            if (!allowAuthorAnimation) {
                 el.style.display = "none";
                 el.classList.remove("author-reveal-static");
                 if (onDone) {


### PR DESCRIPTION
### Motivation
- Mobile users reported a font-size/rendering glitch when toggling hidden authors; the reveal/hide animation using masks can trigger rendering issues on coarse-pointer touch devices and on platforms with reduced-motion preferences.

### Description
- Added touch-device detection and an `allowAuthorAnimation` guard in the publications author-toggle script so animations run only when motion is allowed and the device has a fine pointer, by updating `themes/soldaini/layouts/partials/footer.html`.
- When `allowAuthorAnimation` is false the code falls back to immediate show/hide behavior and applies the static reveal state instead of running the mask/animation path.

### Testing
- Ran `uv run hugo-cli` successfully and confirmed the site builds without errors.
- Attempted `uv run preview-png -- /publications/` but screenshot generation failed in this environment due to missing Playwright host dependencies (automation failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6b2d4059c832da0103e8c506e9e03)