### PR TITLE
Fix author-list toggle spacing and simplify related CSS/HTML

### DIFF
--- a/themes/soldaini/assets/sass/theme.scss
+++ b/themes/soldaini/assets/sass/theme.scss
@@ -675,10 +675,6 @@ hr {
     text-wrap: balance;
 }
 
-.author-name {
-    white-space: nowrap;
-}
-
 .author-marker {
     position: relative;
     top: -0.4em;
@@ -720,10 +716,6 @@ hr {
 
 .publication-entry .short-authors {
     margin: 0 0.25rem 0 0;
-}
-
-.hide-authors:has(> .short-authors[aria-hidden="false"]) {
-    white-space: nowrap;
 }
 
 @media (max-width: $mobile-width) {

--- a/themes/soldaini/layouts/partials/footer.html
+++ b/themes/soldaini/layouts/partials/footer.html
@@ -144,9 +144,9 @@
         // - one contains the text '{num_authors} authors' and is visible
         // - the other contains the text '{innerText}' and is hidden
         hideAuthors[i].innerHTML =
-            ' <span class="short-authors">+' +
+            '<span class="short-authors">+' +
             num_authors +
-            " authors </span>" +
+            " authors</span>" +
             '<span class="long-authors">' +
             innerHTML +
             "</span>";
@@ -162,7 +162,7 @@
         longAuthorsSpan.setAttribute("aria-hidden", "true");
 
         // set the `short-authors` span to be visible and the `long-authors` span to be hidden
-        shortAuthorsSpan.style.display = "inline";
+        shortAuthorsSpan.style.display = "inline-flex";
         longAuthorsSpan.style.display = "none";
 
         // attach the toggleAuthors function to the onclick event of the span


### PR DESCRIPTION
### Motivation
- Improve the author-list toggle so the shortened author marker aligns and wraps correctly across layouts. 
- Remove redundant/fragile CSS rules that interfered with the toggle behavior and relied on complex selectors. 

### Description
- Update the author-toggle HTML generation in `layouts/partials/footer.html` to remove an extra leading space and tighten the generated text spacing. 
- Set the visible `short-authors` span to `display: inline-flex` by default in the script to provide more reliable alignment. 
- Remove the `.author-name { white-space: nowrap; }` rule and the `.hide-authors:has(> .short-authors[aria-hidden="false"]) { white-space: nowrap; }` rule from `themes/soldaini/assets/sass/theme.scss`. 
- Preserve existing accessibility attributes and click handlers for toggling `short-authors`/`long-authors` spans and retain the preprint label replacement logic. 

### Testing
- Compiled the theme SCSS with the project's SASS toolchain and the compilation completed successfully. 
- Built the site with the static site generator (`hugo`) and the build completed without errors. 
- Ran automated frontend checks for syntax and no new linting errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6b5c6aac8832db8777afe416e1887)